### PR TITLE
Rewrite setup script

### DIFF
--- a/setup-fast-engine.sh
+++ b/setup-fast-engine.sh
@@ -1,1 +1,26 @@
-404: Not Found
+#!/usr/bin/env bash
+
+# Fast-Engine setup script
+# Creates a virtual environment and installs project dependencies.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_DIR="$ROOT_DIR/.venv"
+
+# Create virtual environment if it doesn't exist
+if [ ! -d "$VENV_DIR" ]; then
+    python3 -m venv "$VENV_DIR"
+fi
+
+source "$VENV_DIR/bin/activate"
+
+# Upgrade pip and install dependencies
+pip install --upgrade pip
+pip install -r "$ROOT_DIR/requirements.txt"
+
+# Install project in editable mode
+pip install -e "$ROOT_DIR"
+
+echo "\nFast-Engine setup complete. Activate the environment with:\n  source $VENV_DIR/bin/activate"
+echo "Refer to README.md for usage instructions."


### PR DESCRIPTION
## Summary
- rewrite `setup-fast-engine.sh` to provide a usable setup helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: fast_engine)*

------
https://chatgpt.com/codex/tasks/task_e_6873dc43e47c83259f5ddd643cce1a66