### PR TITLE
Implement create_app in FastEngine

### DIFF
--- a/fast_engine/app.py
+++ b/fast_engine/app.py
@@ -1,0 +1,5 @@
+"""Simple application factory used for testing."""
+
+def create_app():
+    """Return a dummy app representation."""
+    return "fast_engine_app"

--- a/fast_engine/core.py
+++ b/fast_engine/core.py
@@ -6,6 +6,7 @@ from typing import Dict, Any, Optional
 from .config import Config
 from .templates import TemplateEngine
 from .utils import ensure_directory, logger
+from .app import create_app as _create_app
 
 class FastEngine:
     """Orquestador principal de Fast-Engine"""
@@ -14,9 +15,9 @@ class FastEngine:
         self.config = Config.load(config_path)
         self.template_engine = TemplateEngine(self.config.templates_path)
 
-    def create_app():
-        # Your implementation here
-        pass
+    def create_app(self):
+        """Return a basic application instance."""
+        return _create_app()
     
     def init_project_demo(self, name: str, template: str = "saas-basic", description: str = "") -> str:
         """Demo de generacion de proyecto (sin APIs reales)"""
@@ -124,3 +125,7 @@ class Engine:
 
     def create_app():
         return "fast_engine_app"
+
+
+# Expose the app factory at module level
+create_app = _create_app


### PR DESCRIPTION
## Summary
- provide a simple app factory in `fast_engine/app.py`
- implement `FastEngine.create_app` using the app factory
- expose the `create_app` function at module level

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873eba2e18883258d4fd0c1bf255409