### PR TITLE
Update CI to set PYTHONPATH before tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,5 @@ jobs:
           pip install -r requirements.txt
       - name: Run tests
         run: |
+          echo "PYTHONPATH=$(pwd)" >> $GITHUB_ENV
           python -m pytest -vv


### PR DESCRIPTION
## Summary
- update GitHub Actions to export `PYTHONPATH` prior to running tests

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873f413204883259aba983fce2a8564