### PR TITLE
Fix Engine.create_app method signature

### DIFF
--- a/fast_engine/core.py
+++ b/fast_engine/core.py
@@ -123,7 +123,7 @@ class Engine:
     def run(self):
         return "running"
 
-    def create_app():
+    def create_app(self):
         return "fast_engine_app"
 
 


### PR DESCRIPTION
## Summary
- add missing `self` parameter in `Engine.create_app`

## Testing
- `PYTHONPATH=$(pwd) pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873f6c6b0248325b27fb9f8904c59da