### PR TITLE
Fix union type usage for Python 3.9

### DIFF
--- a/fast_engine/templates.py
+++ b/fast_engine/templates.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional
 from dataclasses import dataclass
 
 try:
@@ -17,7 +17,7 @@ class Template:
     description: str
     version: str = "0.0.0"
     author: str = "Unknown"
-    path: Path | None = None
+    path: Optional[Path] = None
 
     @classmethod
     def from_file(cls, path: Path) -> "Template":


### PR DESCRIPTION
## Summary
- update `Template` path field to use `Optional[Path]`
- update import accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873fde061d88325a4ffcbb12ed7a3f9