### PR TITLE
fix: clean up public API exports in **init**

### DIFF
--- a/fast_engine/__init__.py
+++ b/fast_engine/__init__.py
@@ -31,6 +31,7 @@ TEMPLATES_PATH = get_templates_path()
 from .core import FastEngine, Engine, create_app
 from .config import Config
 from .templates import Template
+from .deploy import deploy
 
 
 try:
@@ -61,14 +62,7 @@ __all__ = [
     "Config",
     "TEMPLATES_PATH",
     "main",
-]
-
-
-__all__ = [
-    "FastEngine",
-    "cli_app",
-    "Config",
-    "TEMPLATES_PATH",
     "deploy",
-    "create_app",
 ]
+
+


### PR DESCRIPTION
## Summary
- remove duplicate `__all__`
- add `deploy` to public exports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6876b482d2e88325bbc3ac1730439112